### PR TITLE
Preview svg in mint popup

### DIFF
--- a/client/modules/IDE/components/NFTMintModal.jsx
+++ b/client/modules/IDE/components/NFTMintModal.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connect } from 'get-starknet';
+import { useSelector } from 'react-redux';
+import useIframeContent from '../hooks/useIframeContentMintModal';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -13,7 +15,7 @@ const ModalOverlay = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 999;
+  z-index: 40;
 `;
 
 const ModalContent = styled.div`
@@ -31,7 +33,7 @@ const CloseButton = styled.button`
   right: 10px;
   background: none;
   border: none;
-  font-size: 1.5rem;
+  font-size: 2rem;
   cursor: pointer;
 `;
 
@@ -103,8 +105,6 @@ const Button = styled.button`
 const NFTPreview = styled.div`
   width: 100%;
   height: 200px;
-  background: url('https://www.w3schools.com/w3images/avatar2.png') center/cover
-    no-repeat;
   border-radius: 8px;
   margin-bottom: 24px;
   display: flex;
@@ -113,19 +113,7 @@ const NFTPreview = styled.div`
   color: #fff;
   font-size: 1.5em;
   text-align: center;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-`;
-
-const ArtistAvatar = styled.div`
-  width: 100%;
-  height: 120px;
-  background: url('https://www.w3schools.com/w3images/avatar5.png') center/cover
-    no-repeat;
-  border-radius: 8px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 24px;
+  overflow: hidden;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 `;
 
@@ -158,7 +146,11 @@ const NFTMintModal = ({ isOpen, onClose }) => {
     artistName: '',
     artistBio: ''
   });
-  //   const { t } = useTranslation();
+  const files = useSelector((state) => state.files);
+  const svgFile = files.find((file) => file.name === 'sketch.js');
+  const svgContent = svgFile ? svgFile.content : '';
+  const srcDoc = useIframeContent(svgContent);
+  const iframeRef = useRef(null);
 
   const handleInputChange = useCallback((e) => {
     const { name, value } = e.target;
@@ -218,7 +210,6 @@ const NFTMintModal = ({ isOpen, onClose }) => {
           await new Promise((resolve) => setTimeout(resolve, 2000));
           setStep(3);
         } catch (error) {
-          console.error('Minting failed', error);
           setErrors((prev) => ({
             ...prev,
             minting: error.message || 'Minting failed'
@@ -240,7 +231,12 @@ const NFTMintModal = ({ isOpen, onClose }) => {
     <StyledContent>
       <Column>
         <NFTPreview>
-          <span>NFT Preview</span>
+          <iframe
+            title="SVG preview"
+            ref={iframeRef}
+            srcDoc={srcDoc}
+            style={{ width: '100%', height: '500px', border: 'none' }}
+          />
         </NFTPreview>
       </Column>
       <Column>
@@ -274,9 +270,14 @@ const NFTMintModal = ({ isOpen, onClose }) => {
   const renderStep2 = () => (
     <StyledContent>
       <Column>
-        <ArtistAvatar>
-          <span>Artist Avatar</span>
-        </ArtistAvatar>
+        <NFTPreview>
+          <iframe
+            title="SVG preview"
+            ref={iframeRef}
+            srcDoc={srcDoc}
+            style={{ width: '100%', height: '500px', border: 'none' }}
+          />
+        </NFTPreview>
       </Column>
       <Column>
         <SectionTitle>ARTIST SECTION</SectionTitle>

--- a/client/modules/IDE/hooks/useIframeContentMintModal.js
+++ b/client/modules/IDE/hooks/useIframeContentMintModal.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import iframeHtmlTemplate from '../../../utils/mintModalIframeUtils';
+
+const useIframeContent = (svgContent) => {
+  const [srcDoc, setSrcDoc] = useState('');
+
+  useEffect(() => {
+    const content = iframeHtmlTemplate(svgContent);
+    setSrcDoc(content);
+  }, [svgContent]);
+
+  return srcDoc;
+};
+
+export default useIframeContent;

--- a/client/utils/mintModalIframeUtils.js
+++ b/client/utils/mintModalIframeUtils.js
@@ -1,0 +1,21 @@
+const iframeHtmlTemplate = (svgContent) => `
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/p5.js-svg@1.5.0"></script>  
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/addons/p5.sound.min.js"></script>
+  </head>
+  <body>
+    <main>
+      <button id="saveButton">Save SVG</button>
+    </main>
+    <script id="svgScript">
+      ${svgContent}
+    </script>
+  </body>
+  </html>
+  `;
+
+export default iframeHtmlTemplate;


### PR DESCRIPTION
Fixes #24 

Changes:

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #24`


New Features:

useIframeContent Hook: Generates iframe content for displaying SVG previews within the minting modal.
iframeHtmlTemplate Utility: Defines the HTML template for the iframe, including necessary scripts for rendering SVG content.
NFTMintModal Component: A multi-step modal that guides users through the minting process. It includes form fields for NFT details, artist information, and displays a preview of the SVG content in an iframe.
The modal handles validation, user interactions, state management, and error handling. It also integrates with Starknet for the minting process, providing feedback and managing the loading state during the minting operation. (Implemented in #21).

Demo:
[nft_mint_demo.webm](https://github.com/user-attachments/assets/3513f519-3db0-4ecc-9871-1ce2a0509dbe)

 